### PR TITLE
Switch to PDFsharp

### DIFF
--- a/PicCompress/BufferCompressor.cpp
+++ b/PicCompress/BufferCompressor.cpp
@@ -3,6 +3,28 @@
 
 #include <libiodine.h>
 
+namespace {
+
+class IodineString {
+	const char* _msg;
+public:
+	IodineString(const char* msg) :
+		_msg(msg) {
+	}
+
+	~IodineString() {
+		if (nullptr != _msg)
+			c_free_string((char*)_msg);
+		_msg = nullptr;
+	}
+
+	const char* get() const {
+		return _msg;
+	}
+};
+
+}
+
 PicCompress::IodineOutputStream^ PicCompress::BufferCompressor::Compress(
 	_In_ array<System::Byte>^ input,
 	int targetFormat,
@@ -50,13 +72,26 @@ PicCompress::IodineOutputStream^ PicCompress::BufferCompressor::Compress(
 		res = iod_convert_in_memory(input_buffer, input_buffer_len, SupportedFileTypes::Png, parameters, &output_buffer);
 		break;
 	default:
-		throw gcnew System::ArgumentException(System::String::Format("Unknown target type: {0}", targetFormat));
+		throw gcnew System::ArgumentException(System::String::Format("Unknown target type: {0}.", targetFormat));
 	}
+	IodineString err_str{ res.error_message };
 
 	if (!res.success) {
-		System::String^ str = Marshal::PtrToStringAnsi((System::IntPtr)(void*)res.error_message);
-		c_free_string((char*)res.error_message);
-		throw gcnew System::InvalidOperationException(str);
+		if (err_str.get() != nullptr) {
+			System::String^ str = Marshal::PtrToStringAnsi((System::IntPtr)(void*)err_str.get());
+			throw gcnew System::InvalidOperationException(
+				System::String::Format(
+					"Iodine error ({0}): {1}, target: {2}.",
+					res.code, str, targetFormat
+				)
+			);
+		}
+		throw gcnew System::InvalidOperationException(
+			System::String::Format(
+				"Iodine error ({0}), target: {1}.",
+				res.code, targetFormat
+			)
+		);
 	}
 
 	return gcnew PicCompress::IodineOutputStream(output_buffer);

--- a/PicCompress/BufferCompressor.cpp
+++ b/PicCompress/BufferCompressor.cpp
@@ -7,6 +7,7 @@ PicCompress::IodineOutputStream^ PicCompress::BufferCompressor::Compress(
 	_In_ array<System::Byte>^ input,
 	int targetFormat,
 	int quality,
+	bool optimize,
 	bool resize,
 	int width,
 	int height
@@ -16,12 +17,21 @@ PicCompress::IodineOutputStream^ PicCompress::BufferCompressor::Compress(
 	const Byte* input_buffer = input_bytes;
 
 	CCSParameters parameters = {};
+
 	parameters.keep_metadata = false;
+
 	parameters.jpeg_quality = quality;
 	parameters.jpeg_progressive = true;
+	parameters.jpeg_optimize = optimize;
+
 	parameters.png_quality = quality;
+	parameters.png_optimize = optimize;
+
 	parameters.gif_quality = quality;
+
 	parameters.webp_quality = quality;
+	parameters.webp_lossless = optimize;
+
 	if (resize) {
 		parameters.width = width;
 		parameters.height = height;

--- a/PicCompress/BufferCompressor.cpp
+++ b/PicCompress/BufferCompressor.cpp
@@ -3,11 +3,7 @@
 
 #include <libiodine.h>
 
-#include <stdlib.h>
-#include <string.h>
-#include <msclr/marshal.h>
-
-PicCompress::IodineBufferViewer^ PicCompress::BufferCompressor::Compress(
+PicCompress::IodineOutputStream^ PicCompress::BufferCompressor::Compress(
 	_In_ array<System::Byte>^ input,
 	int targetFormat,
 	int quality,
@@ -17,7 +13,7 @@ PicCompress::IodineBufferViewer^ PicCompress::BufferCompressor::Compress(
 ) {
 	pin_ptr<System::Byte> input_bytes(&input[0]);
 	uintptr_t input_buffer_len = input->Length;
-	const byte* input_buffer = input_bytes;
+	const Byte* input_buffer = input_bytes;
 
 	CCSParameters parameters = {};
 	parameters.keep_metadata = false;
@@ -48,10 +44,10 @@ PicCompress::IodineBufferViewer^ PicCompress::BufferCompressor::Compress(
 	}
 
 	if (!res.success) {
-		auto str = msclr::interop::marshal_as<System::String^>(res.error_message);
+		System::String^ str = Marshal::PtrToStringAnsi((System::IntPtr)(void*)res.error_message);
 		c_free_string((char*)res.error_message);
 		throw gcnew System::InvalidOperationException(str);
 	}
 
-	return gcnew PicCompress::IodineBufferViewer(output_buffer);
+	return gcnew PicCompress::IodineOutputStream(output_buffer);
 }

--- a/PicCompress/BufferCompressor.h
+++ b/PicCompress/BufferCompressor.h
@@ -21,6 +21,7 @@ public:
 		_In_ array<System::Byte>^ input,
 		int targetFormat,
 		int quality,
+		bool optimize,
 		bool resize,
 		int width,
 		int height

--- a/PicCompress/BufferCompressor.h
+++ b/PicCompress/BufferCompressor.h
@@ -1,6 +1,6 @@
 ﻿#pragma once
 
-#include "IodineBufferViewer.h"
+#include "IodineOutputStream.h"
 
 namespace PicCompress {
 
@@ -17,7 +17,7 @@ public:
 	 * @param quality: 压缩之目标质量。
 	 * @return 已写入输出文件 之 大小（字节）。
 	 */
-	static IodineBufferViewer^ Compress(
+	static IodineOutputStream^ Compress(
 		_In_ array<System::Byte>^ input,
 		int targetFormat,
 		int quality,

--- a/PicCompress/IodineOutputStream.cpp
+++ b/PicCompress/IodineOutputStream.cpp
@@ -1,0 +1,31 @@
+﻿#include "IodineOutputStream.h"
+
+namespace PicCompress {
+
+IodineOutputStream::~IodineOutputStream() {
+	this->!IodineOutputStream();
+}
+
+IodineOutputStream::!IodineOutputStream() {
+	if (m_buffer != nullptr) {
+		CByteArray buffer{};
+		buffer.data = m_buffer;
+		buffer.length = m_length;
+		iod_free_buffer(buffer);
+	}
+	m_buffer = nullptr;
+	m_length = 0;
+	m_position = 0;
+}
+
+IodineOutputStream::IodineOutputStream(CByteArray buffer) :
+	m_position(0) {
+	if (buffer.length >= System::Int64::MaxValue) {
+		iod_free_buffer(buffer);
+		throw gcnew System::InsufficientMemoryException("The buffer from iodine is too large");
+	}
+	m_buffer = buffer.data;
+	m_length = static_cast<int>(buffer.length);
+}
+
+}

--- a/PicCompress/IodineOutputStream.h
+++ b/PicCompress/IodineOutputStream.h
@@ -1,0 +1,127 @@
+﻿#pragma once
+
+#include <libiodine.h>
+
+using namespace System;
+using namespace System::IO;
+using namespace System::Runtime::InteropServices;
+
+namespace PicCompress {
+
+public ref class IodineOutputStream : public Stream {
+private:
+	Byte* m_buffer;    // 非托管缓冲区指针
+	Int64 m_length;    // 缓冲区总大小（字节）
+	Int64 m_position;  // 当前流位置
+
+protected:
+	virtual ~IodineOutputStream();
+	!IodineOutputStream();
+
+public:
+	// 构造函数：包装现有非托管内存（不拥有）
+	IodineOutputStream(CByteArray buffer);
+
+	// 实现 Stream 抽象属性
+	virtual property bool CanRead { bool get() override {
+		return nullptr != m_buffer;
+	} };
+	virtual property bool CanSeek { bool get() override {
+		return nullptr != m_buffer;
+	} };
+	virtual property bool CanWrite { bool get() override {
+		return false;
+	} };
+	virtual property Int64 Length { Int64 get() override {
+		return m_length;
+	} };
+
+	virtual property Int64 Position {
+		Int64 get() override {
+			return m_position;
+		}
+		void set(Int64 value) override {
+			if (value < 0 || value > m_length)
+				throw gcnew ArgumentOutOfRangeException("Position");
+			m_position = value;
+		}
+	};
+
+	// 读取数据到托管 byte[]（复制）
+	virtual int Read(array<Byte>^ buffer, int offset, int count) override {
+		if (nullptr == m_buffer)
+			throw gcnew System::ObjectDisposedException("disposed");
+		if (buffer == nullptr) throw gcnew ArgumentNullException("buffer");
+		if (offset < 0 || count < 0) throw gcnew ArgumentOutOfRangeException();
+		if (offset + count > buffer->Length) throw gcnew ArgumentException("Buffer too small");
+
+		Int64 bytesToRead = Math::Min((Int64)count, m_length - m_position);
+		if (bytesToRead <= 0) return 0;
+
+		// 直接复制非托管内存到托管数组
+		Marshal::Copy(IntPtr(m_buffer + m_position), buffer, offset, (int)bytesToRead);
+		m_position += bytesToRead;
+		return (int)bytesToRead;
+	}
+
+	// 写入数据（从托管 byte[]）
+	virtual void Write(array<Byte>^ buffer, int offset, int count) override {
+		/*只读流*/
+		throw gcnew NotSupportedException("Stream does not support writing");
+	}
+
+	// 查找
+	virtual Int64 Seek(Int64 offset, SeekOrigin origin) override {
+		if (nullptr == m_buffer)
+			throw gcnew System::ObjectDisposedException("disposed");
+		Int64 newPos;
+		switch (origin) {
+		case SeekOrigin::Begin:   newPos = offset; break;
+		case SeekOrigin::Current: newPos = m_position + offset; break;
+		case SeekOrigin::End:     newPos = m_length + offset; break;
+		default: throw gcnew ArgumentException("Invalid seek origin");
+		}
+		if (newPos < 0 || newPos > m_length)
+			throw gcnew IOException("Seek position out of range");
+		m_position = newPos;
+		return m_position;
+	}
+
+	virtual void SetLength(Int64 value) override {
+		// 不支持更改长度（若需支持，需重新分配内存并复制）
+		throw gcnew NotSupportedException("Resizing is not supported");
+	}
+
+	virtual void Flush() override {
+		/* 无操作，因为是内存流 */
+		if (nullptr == m_buffer)
+			throw gcnew System::ObjectDisposedException("disposed");
+	}
+
+	// 额外：提供索引器，方便按字节访问
+	property Byte Item[Int64]{
+		Byte get(Int64 index) {
+			if (nullptr == m_buffer)
+				throw gcnew System::ObjectDisposedException("disposed");
+			if (index < 0 || index >= m_length)
+				throw gcnew IndexOutOfRangeException();
+			return m_buffer[index];
+		}
+		void set(Int64 index, Byte value) {
+			if (nullptr == m_buffer)
+				throw gcnew System::ObjectDisposedException("disposed");
+			if (index < 0 || index >= m_length)
+				throw gcnew IndexOutOfRangeException();
+			m_buffer[index] = value;
+		}
+	};
+
+	// 获取底层指针（谨慎使用）
+	Byte* GetBufferPointer() {
+		if (nullptr == m_buffer)
+			throw gcnew System::ObjectDisposedException("disposed");
+		return m_buffer;
+	}
+};
+
+}

--- a/PicCompress/PicCompress.vcxproj
+++ b/PicCompress/PicCompress.vcxproj
@@ -64,6 +64,7 @@
       <LanguageStandard_C>stdc17</LanguageStandard_C>
       <AdditionalIncludeDirectories>$(OHMS_LIB_DIR)\libiodine\v0.20.3\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <EnableEnhancedInstructionSet>AdvancedVectorExtensions2</EnableEnhancedInstructionSet>
+      <StringPooling>true</StringPooling>
     </ClCompile>
     <Link>
       <AdditionalDependencies>iodine.dll.lib</AdditionalDependencies>
@@ -81,6 +82,7 @@
       <LanguageStandard_C>stdc17</LanguageStandard_C>
       <AdditionalIncludeDirectories>$(OHMS_LIB_DIR)\libiodine\v0.20.3\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <EnableEnhancedInstructionSet>AdvancedVectorExtensions2</EnableEnhancedInstructionSet>
+      <StringPooling>true</StringPooling>
     </ClCompile>
     <Link>
       <AdditionalDependencies>iodine.dll.lib</AdditionalDependencies>
@@ -90,12 +92,14 @@
   <ItemGroup>
     <ClInclude Include="BufferCompressor.h" />
     <ClInclude Include="IodineBufferViewer.h" />
+    <ClInclude Include="IodineOutputStream.h" />
     <ClInclude Include="Resource.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="AssemblyInfo.cpp" />
     <ClCompile Include="BufferCompressor.cpp" />
     <ClCompile Include="IodineBufferViewer.cpp" />
+    <ClCompile Include="IodineOutputStream.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="app.rc" />

--- a/PicCompress/PicCompress.vcxproj.filters
+++ b/PicCompress/PicCompress.vcxproj.filters
@@ -24,6 +24,9 @@
     <ClInclude Include="Resource.h">
       <Filter>资源文件</Filter>
     </ClInclude>
+    <ClInclude Include="IodineOutputStream.h">
+      <Filter>头文件</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="BufferCompressor.cpp">
@@ -34,6 +37,9 @@
     </ClCompile>
     <ClCompile Include="AssemblyInfo.cpp">
       <Filter>资源文件</Filter>
+    </ClCompile>
+    <ClCompile Include="IodineOutputStream.cpp">
+      <Filter>源文件</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/PicMergeToPdf/CompressTarget.cs
+++ b/PicMergeToPdf/CompressTarget.cs
@@ -5,32 +5,16 @@ using SixLabors.ImageSharp.Processing;
 
 namespace PicMerge {
 	internal static class CompressTarget {
-		public static byte[] GetCompressedImageData(in byte[] input, ImageParam param) {
-#if DEBUG
-			if (param.reduceByPowOf2 || param.shortSide != 0 || param.longSide != 0) {
-				throw new ArgumentException("Extra parameters not processed.");
-			}
-			if (param.resize && (param.width < 1 || param.height < 1)) {
-				throw new ArgumentException("Parameters is invalid.");
-			}
-#endif
-			using var iodine_buf = PicCompress.BufferCompressor.Compress(
-				input, param.format, param.quality,
+		public static Stream GetCompressedImageData(in byte[] input, ImageParam param, bool opimize) {
+			var iodine_steam = PicCompress.BufferCompressor.Compress(
+				input, param.format, param.quality, opimize,
 				param.resize, param.width, param.height
 			);
-			return iodine_buf.ToArray();
+			return iodine_steam;
 		}
 
-		public static byte[] GetImageSharpData(in Image input_image, ImageParam param) {
-#if DEBUG
-			if (param.reduceByPowOf2 || param.shortSide != 0 || param.longSide != 0) {
-				throw new ArgumentException("Extra parameters not processed.");
-			}
-			if (param.resize && (param.width < 1 || param.height < 1)) {
-				throw new ArgumentException("Parameters is invalid.");
-			}
-#endif
-			using MemoryStream imgSt = new();
+		public static Stream GetImageSharpData(in Image input_image, ImageParam param) {
+			MemoryStream imgSt = new();
 
 			if (param.resize) {
 				input_image.Mutate(x => x.Resize(param.width, param.height));
@@ -70,7 +54,8 @@ namespace PicMerge {
 				break;
 			}
 			}
-			return imgSt.ToArray();
+
+			return imgSt;
 		}
 	}
 }

--- a/PicMergeToPdf/CompressTarget.cs
+++ b/PicMergeToPdf/CompressTarget.cs
@@ -21,17 +21,7 @@ namespace PicMerge {
 			}
 
 			switch (param.format) {
-			case 1: { // JPEG
-				JpegEncoder encoder = new() {
-					SkipMetadata = true,
-					ColorType = JpegEncodingColor.Rgb,
-					Quality = param.quality,
-					Interleaved = false
-				};
-				input_image.SaveAsJpeg(imgSt, encoder);
-				break;
-			}
-			default: {
+			case 2: { // PNG
 				int quality = 10 - param.quality / 10;
 				PngEncoder encoder = new() {
 					SkipMetadata = true,
@@ -51,6 +41,17 @@ namespace PicMerge {
 					}
 				};
 				input_image.SaveAsPng(imgSt, encoder);
+				break;
+			}
+			//case 1:// JPEG
+			default: { // others
+				JpegEncoder encoder = new() {
+					SkipMetadata = true,
+					ColorType = JpegEncodingColor.Rgb,
+					Quality = param.quality,
+					Interleaved = false
+				};
+				input_image.SaveAsJpeg(imgSt, encoder);
 				break;
 			}
 			}

--- a/PicMergeToPdf/CompressTarget.cs
+++ b/PicMergeToPdf/CompressTarget.cs
@@ -21,7 +21,17 @@ namespace PicMerge {
 			}
 
 			switch (param.format) {
-			case 2: {
+			case 1: { // JPEG
+				JpegEncoder encoder = new() {
+					SkipMetadata = true,
+					ColorType = JpegEncodingColor.Rgb,
+					Quality = param.quality,
+					Interleaved = false
+				};
+				input_image.SaveAsJpeg(imgSt, encoder);
+				break;
+			}
+			default: {
 				int quality = 10 - param.quality / 10;
 				PngEncoder encoder = new() {
 					SkipMetadata = true,
@@ -41,16 +51,6 @@ namespace PicMerge {
 					}
 				};
 				input_image.SaveAsPng(imgSt, encoder);
-				break;
-			}
-			default: {
-				JpegEncoder encoder = new() {
-					SkipMetadata = true,
-					ColorType = JpegEncodingColor.Rgb,
-					Quality = param.quality,
-					Interleaved = false
-				};
-				input_image.SaveAsJpeg(imgSt, encoder);
 				break;
 			}
 			}

--- a/PicMergeToPdf/FileType.cs
+++ b/PicMergeToPdf/FileType.cs
@@ -15,38 +15,57 @@ namespace PicMerge {
 		}
 
 		internal static Type CheckType(Stream file) {
+			var oldpos = file.Position;
+
 			byte[] b = new byte[8];
 			if (file.Read(b, 0, 8) != 8)
 				return Type.Unknown;
-			return CheckType(b);
+			var res = CheckType(b);
+
+			file.Position = oldpos;
+			return res;
 		}
 
 		internal static Type CheckType(byte[] b) {
-			Type res = Type.Unknown;
 
-			if (b[0] == 0xFF && b[1] == 0xD8) {
-				res = Type.JPEG;
-			}
-			else if (b[0] == 'B' && b[1] == 'M') {
-				res = Type.BMP;
-			}
-			else if (b[0] == 'G' && b[1] == 'I' && b[2] == 'F') {
-				res = Type.GIF;
-			}
-			else if (b[0] == 'R' && b[1] == 'I' && b[2] == 'F' && b[3] == 'F') {
-				res = Type.WEBP;
-			}
-			else if (b[0] == 0x89 && b[1] == 'P' && b[2] == 'N' && b[3] == 'G' && b[4] == 0x0D && b[5] == 0x0A && b[6] == 0x1A && b[7] == 0x0A) {
-				res = Type.PNG;
-			}
-			else if (b[0] == b[1] && b[1] == 'I' && b[2] == 0x2A && b[3] == 0x00) {
-				res = Type.TIFF;
-			}
-			else if (b[0] == b[1] && b[1] == 'M' && b[2] == 0x00 && b[3] == 0x2A) {
-				res = Type.TIFF;
-			}
+			if (b.Length < 2)
+				return Type.Unknown;
 
-			return res;
+			if (b[0] == 0xFF && b[1] == 0xD8)
+				return Type.JPEG;
+
+			if (b[0] == 'B' && b[1] == 'M')
+				return Type.BMP;
+
+
+			if (b.Length < 3)
+				return Type.Unknown;
+
+			if (b[0] == 'G' && b[1] == 'I' && b[2] == 'F')
+				return Type.GIF;
+
+
+			if (b.Length < 4)
+				return Type.Unknown;
+
+			if (b[0] == 'R' && b[1] == 'I' && b[2] == 'F' && b[3] == 'F')
+				return Type.WEBP;
+
+			if (b[0] == b[1] && b[1] == 'I' && b[2] == 0x2A && b[3] == 0x00)
+				return Type.TIFF;
+
+			if (b[0] == b[1] && b[1] == 'M' && b[2] == 0x00 && b[3] == 0x2A)
+				return Type.TIFF;
+
+
+			if (b.Length < 8)
+				return Type.Unknown;
+
+			if (b[0] == 0x89 && b[1] == 'P' && b[2] == 'N' && b[3] == 'G' && b[4] == 0x0D && b[5] == 0x0A && b[6] == 0x1A && b[7] == 0x0A)
+				return Type.PNG;
+
+
+			return Type.Unknown;
 		}
 
 	}

--- a/PicMergeToPdf/Merger.cs
+++ b/PicMergeToPdf/Merger.cs
@@ -8,6 +8,13 @@ namespace PicMerge {
 
 		protected readonly object m_lock = new(); // Used to avoid IO at the same time.
 
+		internal enum Loader {
+			NULL,
+			Iodine,
+			ImageSharp,
+			PDFsharp,
+		}
+
 		internal struct LoadImageLog(string msg) {
 			public string error_message = msg;
 
@@ -33,6 +40,7 @@ namespace PicMerge {
 		/// <returns>加载结果</returns>
 		internal LoadImageResult LoadImage(string filepath, ImageParam param) {
 			LoadImageResult res = new($"[Load] Loading \'{filepath}\'...");
+			Loader loader = Loader.NULL;
 			try {
 				byte[] buffer;
 				lock (m_lock) { // 防止同时IO
@@ -42,7 +50,7 @@ namespace PicMerge {
 					inputStream.ReadExactly(buffer, 0, (int)inputStream.Length);
 					inputStream.Close();
 				}
-				res.output = ReadImage(in buffer, param, ref res.log, out res.img_w_override, out res.img_h_override);
+				(res.output, loader) = ReadImage(in buffer, param, ref res.log, out res.img_w_override, out res.img_h_override);
 			}
 			catch (Exception ex) {
 				res.log += $"[Load] Exception: {ex.Message}";
@@ -52,7 +60,7 @@ namespace PicMerge {
 				res.log += $"[Load] Loading '{filepath}' Failed.";
 			}
 			else {
-				res.log += $"[Load] '{filepath}' Loaded.";
+				res.log += $"[Load] '{filepath}' Loaded by {loader}.";
 			}
 			return res;
 		}
@@ -62,8 +70,9 @@ namespace PicMerge {
 		/// </summary>
 		/// <param name="input">要读入之图片之文件流</param>
 		/// <returns>加载结果</returns>
-		internal static Stream? ReadImage(in byte[] buffer, ImageParam param, ref LoadImageLog log, out int img_w_or, out int img_h_or) {
+		internal static (Stream?, Loader) ReadImage(in byte[] buffer, ImageParam param, ref LoadImageLog log, out int img_w_or, out int img_h_or) {
 			Stream? img_stream = null;
+			Loader loader = Loader.NULL;
 			img_w_or = -1;
 			img_h_or = -1;
 			try {
@@ -73,7 +82,7 @@ namespace PicMerge {
 				log += $"[Read] Image format: '{type}'.";
 
 				if (type == FileType.Type.Unknown)
-					return null;
+					return (null, Loader.NULL);
 
 				log += $"[Read] Checking in... (invalid file if no 'checked in' followed)";
 				using Image image = Image.Load(buffer);
@@ -99,18 +108,18 @@ namespace PicMerge {
 					// 先尝试Iodine，最大化压缩率；
 					// 再尝试ImageSharp，转换的同时可以压缩；
 					// 最后尝试直接加载。
-					img_stream ??= LoadImgaeByIodine(type, in buffer, param, optimize, ref log);
-					img_stream ??= LoadImageByImageSharp(type, in image, param, ref log);
-					img_stream ??= LoadImageDirectly(type, in buffer, param, ref log, out img_w_or, out img_h_or);
+					img_stream ??= LoadImgaeByIodine(type, in buffer, param, optimize, ref log, out loader);
+					img_stream ??= LoadImageByImageSharp(type, in image, param, ref log, out loader);
+					img_stream ??= LoadImageDirectly(type, in buffer, param, ref log, out loader, out img_w_or, out img_h_or);
 				}
 				else {
 					// 既不压缩、也不改变大小时：
 					// 先尝试直接加载，忽略计算的图片尺寸；
 					// 再尝试ImageSharp，可读取的格式更多；
 					// 最后尝试Iodine，不能闲着。（www
-					img_stream ??= LoadImageDirectly(type, in buffer, param, ref log, out _, out _);
-					img_stream ??= LoadImageByImageSharp(type, in image, param, ref log);
-					img_stream ??= LoadImgaeByIodine(type, in buffer, param, optimize, ref log);
+					img_stream ??= LoadImageDirectly(type, in buffer, param, ref log, out loader, out _, out _);
+					img_stream ??= LoadImageByImageSharp(type, in image, param, ref log, out loader);
+					img_stream ??= LoadImgaeByIodine(type, in buffer, param, optimize, ref log, out loader);
 				}
 
 				if (img_stream is null) {
@@ -121,10 +130,10 @@ namespace PicMerge {
 				log += $"[Read] Exception: {ex.Message}";
 				img_stream = null;
 			}
-			return img_stream;
+			return (img_stream, loader);
 		}
 
-		protected static Stream? LoadImgaeByIodine(FileType.Type type, in byte[] buffer, ImageParam param, bool optimize, ref LoadImageLog log) {
+		protected static Stream? LoadImgaeByIodine(FileType.Type type, in byte[] buffer, ImageParam param, bool optimize, ref LoadImageLog log, out Loader loader) {
 			Stream? imageData = null;
 			switch (type) {
 			case FileType.Type.WEBP: // Iodine, Img#.
@@ -156,11 +165,15 @@ namespace PicMerge {
 			}
 			if (imageData is null) {
 				log += $"[Iodine] Cannot do it. Type: '{type}'.";
+				loader = Loader.NULL;
+			}
+			else {
+				loader = Loader.Iodine;
 			}
 			return imageData;
 		}
 
-		protected static Stream? LoadImageByImageSharp(FileType.Type type, in Image image, ImageParam param, ref LoadImageLog log) {
+		protected static Stream? LoadImageByImageSharp(FileType.Type type, in Image image, ImageParam param, ref LoadImageLog log, out Loader loader) {
 			Stream? imageData = null;
 			switch (type) {
 			case FileType.Type.GIF:  // Iodine, Img#.
@@ -192,11 +205,15 @@ namespace PicMerge {
 			}
 			if (imageData is null) {
 				log += $"[ImageSharp] Cannot do it. Type: '{type}'.";
+				loader = Loader.NULL;
+			}
+			else {
+				loader = Loader.ImageSharp;
 			}
 			return imageData;
 		}
 
-		private static MemoryStream? LoadImageDirectly(FileType.Type type, in byte[] buffer, ImageParam param, ref LoadImageLog log, out int img_w, out int img_h) {
+		private static MemoryStream? LoadImageDirectly(FileType.Type type, in byte[] buffer, ImageParam param, ref LoadImageLog log, out Loader loader, out int img_w, out int img_h) {
 			if (param.resize) {
 				img_w = param.width;
 				img_h = param.height;
@@ -215,6 +232,7 @@ namespace PicMerge {
 			case FileType.Type.BMP:  // Img#.
 			default:
 				log += $"[PDFsharp] Not supports '{type}'.";
+				loader = Loader.NULL;
 				return null;
 			}
 			MemoryStream? res;
@@ -227,6 +245,10 @@ namespace PicMerge {
 			}
 			if (res is null) {
 				log += $"[PDFsharp] Cannot do it. Type: '{type}'.";
+				loader = Loader.NULL;
+			}
+			else {
+				loader = Loader.PDFsharp;
 			}
 			return res;
 		}

--- a/PicMergeToPdf/Merger.cs
+++ b/PicMergeToPdf/Merger.cs
@@ -1,5 +1,4 @@
-﻿using iText.IO.Image;
-using SixLabors.ImageSharp;
+﻿using SixLabors.ImageSharp;
 
 namespace PicMerge {
 	internal class Merger() {
@@ -9,8 +8,8 @@ namespace PicMerge {
 
 		protected readonly object m_lock = new(); // Used to avoid IO at the same time.
 
-		internal struct LoadImageLog() {
-			public string error_message = "";
+		internal struct LoadImageLog(string msg) {
+			public string error_message = msg;
 
 			public void operator +=(string msg) {
 				error_message += Environment.NewLine;
@@ -18,27 +17,42 @@ namespace PicMerge {
 			}
 		}
 
+		internal struct LoadImageResult(string msg) {
+			public Stream? output = null;
+
+			public LoadImageLog log = new(msg);
+
+			public int img_w_override = -1;
+			public int img_h_override = -1;
+		}
+
 		/// <summary>
 		/// 用于从文件加载图片。
 		/// </summary>
 		/// <param name="filepath">图片文件路径</param>
 		/// <returns>加载结果</returns>
-		internal ImageData? LoadImage(string filepath, ImageParam param, ref LoadImageLog log) {
-			log.error_message = $"[Load] Loading \'{filepath}\'...";
-			ImageData? res;
+		internal LoadImageResult LoadImage(string filepath, ImageParam param) {
+			LoadImageResult res = new($"[Load] Loading \'{filepath}\'...");
 			try {
-				using FileStream inputStream = new(filepath, FileMode.Open, FileAccess.Read, FileShare.Read);
-				res = ReadImage(inputStream, param, ref log);
+				byte[] buffer;
+				lock (m_lock) { // 防止同时IO
+					using FileStream inputStream = new(filepath, FileMode.Open, FileAccess.Read, FileShare.Read);
+					inputStream.Seek(0, SeekOrigin.Begin);
+					buffer = new byte[inputStream.Length];
+					inputStream.ReadExactly(buffer, 0, (int)inputStream.Length);
+					inputStream.Close();
+				}
+				res.output = ReadImage(in buffer, param, ref res.log, out res.img_w_override, out res.img_h_override);
 			}
 			catch (Exception ex) {
-				res = null;
-				log += $"[Load] Exception: {ex.Message} by {ex.Source}.";
+				res.log += $"[Load] Exception from '{ex.Source}': {ex.Message}";
+				res.output = null;
 			}
-			if (res == null) {
-				log += $"[Load] Failed loading \'{filepath}\'.";
+			if (res.output is null) {
+				res.log += $"[Load] Loading '{filepath}' Failed.";
 			}
 			else {
-				log += $"[Load] Loaded \'{filepath}\'.";
+				res.log += $"[Load] '{filepath}' Loaded.";
 			}
 			return res;
 		}
@@ -46,225 +60,158 @@ namespace PicMerge {
 		/// <summary>
 		/// 从内存映射文件读取图片。
 		/// </summary>
-		/// <param name="instream">要读入之图片之文件流</param>
+		/// <param name="input">要读入之图片之文件流</param>
 		/// <returns>加载结果</returns>
-		internal ImageData? ReadImage(Stream instream, ImageParam param, ref LoadImageLog log) {
+		internal static Stream? ReadImage(in byte[] buffer, ImageParam param, ref LoadImageLog log, out int img_w_or, out int img_h_or) {
+			Stream? img_stream = null;
+			img_w_or = -1;
+			img_h_or = -1;
 			try {
-				if (instream.Length > int.MaxValue || instream.Length < 8) {
-					return null;
-				}
 				FileType.Type type;
-				byte[] inbuffer;
-				lock (m_lock) {
-					type = FileType.CheckType(instream);
-					if (type == FileType.Type.Unknown) {
-						return null;
-					}
-					instream.Seek(0, SeekOrigin.Begin);
-					inbuffer = new byte[instream.Length];
-					instream.ReadExactly(inbuffer, 0, (int)instream.Length);
-				}
-				log += $"[Read] Image format: {type}.";
+				type = FileType.CheckType(buffer);
 
-				return param.compress ? LoadImageInMemory_Compress(type, in inbuffer, param, ref log) : LoadImageInMemory_Direct(type, in inbuffer, param, ref log);
+				log += $"[Read] Image format: '{type}'.";
+
+				if (type == FileType.Type.Unknown)
+					return null;
+
+				log += $"[Read] Checking in... (invalid file if no 'checked in' followed)";
+				using Image image = Image.Load(buffer);
+				log += $"[Read] Checked in.";
+
+				/// 计算尺寸
+				param = ProcessExtra(image.Width, image.Height, param);
+#if DEBUG
+				log += $"[Read] Computed size: {param.width}, {param.height}";
+				if (param.reduceByPowOf2 || param.shortSide != 0 || param.longSide != 0) {
+					throw new ArgumentException("Extra parameters not processed.");
+				}
+				if (param.resize && (param.width < 1 || param.height < 1)) {
+					throw new ArgumentException("Parameters is invalid.");
+				}
+#endif
+				bool optimize = !param.compress; // 不压缩则使用优化
+				if (optimize) // 优化则使质量最高，保证不接收optimize的格式也能接近无损
+					param.quality = 100;
+
+				if (param.compress || param.resize) {
+					// 压缩和改变大小都需要尝试处理：
+					// 先尝试Iodine，最大化压缩率；
+					// 再尝试ImageSharp，转换的同时可以压缩；
+					// 最后尝试直接加载。
+					img_stream ??= LoadImgaeByIodine(type, in buffer, param, optimize, ref log);
+					img_stream ??= LoadImageByImageSharp(type, in image, param, ref log);
+					img_stream ??= LoadImageDirectly(type, in buffer, param, ref log, out img_w_or, out img_h_or);
+				}
+				else {
+					// 既不压缩、也不改变大小时：
+					// 先尝试直接加载，忽略计算的图片尺寸；
+					// 再尝试ImageSharp，可读取的格式更多；
+					// 最后尝试Iodine，不能闲着。（www
+					img_stream ??= LoadImageDirectly(type, in buffer, param, ref log, out _, out _);
+					img_stream ??= LoadImageByImageSharp(type, in image, param, ref log);
+					img_stream ??= LoadImgaeByIodine(type, in buffer, param, optimize, ref log);
+				}
+
+				if (img_stream is null) {
+					log += $"[Read] Reading Failed, no any tool supports the format.";
+				}
 			}
 			catch (Exception ex) {
-				log += $"[Read] Exception: {ex.Message} by {ex.Source}.";
-				return null;
+				log += $"[Read] Exception from '{ex.Source}': {ex.Message}";
+				img_stream = null;
 			}
+			return img_stream;
 		}
 
-		/// <summary>
-		/// 尝试压缩全部图片时的加载逻辑。
-		/// </summary>
-		/// <returns>加载出的数据，或者 null 若无法加载</returns>
-		protected ImageData? LoadImageInMemory_Compress(FileType.Type type, in byte[] inbuffer, ImageParam param, ref LoadImageLog log) {
-			log += $"[Read] Reading... (Invalid image if failed)";
-			using Image image = Image.Load(inbuffer);
-			log += $"[Read] Finished. Valid image.";
-
-			/// 计算尺寸
-			param = ProcessExtra(image.Width, image.Height, param);
-#if DEBUG
-			log += $"[Read] Computed size: {param.width}, {param.height}";
-#endif
-
-			ImageData? imageData = null;
+		protected static Stream? LoadImgaeByIodine(FileType.Type type, in byte[] buffer, ImageParam param, bool optimize, ref LoadImageLog log) {
+			Stream? imageData = null;
 			switch (type) {
-			case FileType.Type.JPEG: // Iodine, Img#, Direct.
-			case FileType.Type.PNG:  // Iodine, Img#, Direct.
-			case FileType.Type.GIF:  // Iodine, Img#, Direct.
-			case FileType.Type.TIFF: // Iodine, Img#, Direct.
-				/// 尝试利用 Caesium-Iodine 压缩
-				try {
-					byte[] outbuffer = CompressTarget.GetCompressedImageData(in inbuffer, param);
-					imageData = ImageDataFactory.Create(outbuffer);
-					imageData.SetDpi(
-						PdfTarget.BaseDpiForDirectLoadComputingSize,
-						PdfTarget.BaseDpiForDirectLoadComputingSize
-					);
-				}
-				catch (Exception ex) {
-					log += $"[Iodine] Exception: {ex.Message} by {ex.Source}.";
-					imageData = null;
-				}
-				if (imageData == null)
-					goto case FileType.Type.BMP;
-				break;
 			case FileType.Type.WEBP: // Iodine, Img#.
-				/// 尝试利用 Caesium-Iodine 压缩
-				try {
-					var ppp = param;
-					ppp.format = 1; // WEBP必须转换
-					byte[] outbuffer = CompressTarget.GetCompressedImageData(in inbuffer, ppp);
-					imageData = ImageDataFactory.Create(outbuffer);
-					imageData.SetDpi(
-						PdfTarget.BaseDpiForDirectLoadComputingSize,
-						PdfTarget.BaseDpiForDirectLoadComputingSize
-					);
-				}
-				catch (Exception ex) {
-					log += $"[Iodine] Exception: {ex.Message} by {ex.Source}.";
-					imageData = null;
-				}
-				if (imageData == null)
-					goto case FileType.Type.BMP;
-				break;
-			case FileType.Type.BMP:  // Img#, Direct.
-				/// 尝试利用 ImageSharp 压缩
-				try {
-					byte[] outbuffer = CompressTarget.GetImageSharpData(in image, param);
-					imageData = ImageDataFactory.Create(outbuffer);
-					imageData.SetDpi(
-						PdfTarget.BaseDpiForDirectLoadComputingSize,
-						PdfTarget.BaseDpiForDirectLoadComputingSize
-					);
-				}
-				catch (Exception ex) {
-					log += $"[ImageSharp] Exception: {ex.Message} by {ex.Source}.";
-					imageData = null;
-				}
-				if (imageData == null)
-					goto default;
-				break;
-			default:
-				/// 尝试 直接加载
-				try {
-					imageData = CreateWithCheckingResize(in inbuffer, param);
-				}
-				catch (Exception ex) {
-					log += $"[iText] Exception: {ex.Message} by {ex.Source}.";
-					imageData = null;
-				}
-				break;
-			}
-			return imageData;
-		}
-
-		/// <summary>
-		/// 直接读取时（不全部压缩）的加载逻辑。
-		/// </summary>
-		/// <returns>加载出的数据，或者 null 若无法加载</returns>
-		protected ImageData? LoadImageInMemory_Direct(FileType.Type type, in byte[] inbuffer, ImageParam param, ref LoadImageLog log) {
-			Image? image = null;
-			try {
-				image = Image.Load(inbuffer);
-			}
-			catch {
-				log.error_message += Environment.NewLine;
-				log.error_message += $"[Read] Error: Invalid image file.";
-				return null;
-			}
-
-			/// 计算尺寸
-			param = ProcessExtra(image.Width, image.Height, param);
-#if DEBUG
-			log += $"[Read] Computed size: {param.width}, {param.height}";
-#endif
-			param.quality = 100; // 不压缩
-
-			ImageData? imageData = null;
-			switch (type) {
-			case FileType.Type.JPEG: // Iodine, Img#, Direct.
-			case FileType.Type.PNG:  // Iodine, Img#, Direct.
-			case FileType.Type.GIF:  // Iodine, Img#, Direct.
-			case FileType.Type.TIFF: // Iodine, Img#, Direct.
-			case FileType.Type.BMP:  // Img#, Direct.
-				/// 尝试 直接加载
-				try {
-					imageData = CreateWithCheckingResize(in inbuffer, param);
-				}
-				catch (Exception ex) {
-					log += $"[iText] Exception: {ex.Message} by {ex.Source}.";
-					imageData = null;
-					goto case FileType.Type.WEBP;
-				}
-				break;
-			case FileType.Type.WEBP: // Iodine, Img#.
-				/// 尝试利用 ImageSharp 转化
-				try {
-					byte[] outbuffer = CompressTarget.GetImageSharpData(in image, param);
-					imageData = ImageDataFactory.Create(outbuffer);
-					imageData.SetDpi(
-						PdfTarget.BaseDpiForDirectLoadComputingSize,
-						PdfTarget.BaseDpiForDirectLoadComputingSize
-					);
-				}
-				catch (Exception ex) {
-					log += $"[ImageSharp] Exception: {ex.Message} by {ex.Source}.";
-					imageData = null;
-				}
-				if (type == FileType.Type.BMP)
+				switch (param.format) {
+				case 1: // JPEG
+				case 2: // PNG
 					break;
-				if (imageData == null)
-					goto default;
-				break;
-			default:
-				/// 尝试利用 Iodine 转化
+				case 0: // 原格式
+				default:
+					param.format = 1; // WEBP必须转换
+					break;
+				}
+				goto case FileType.Type.JPEG;
+			case FileType.Type.JPEG: // Iodine, Img#, Direct.
+			case FileType.Type.PNG:  // Iodine, Img#, Direct.
+			case FileType.Type.GIF:  // Iodine, Img#, Direct.
+			case FileType.Type.TIFF: // Iodine, Img#, Direct.
 				try {
-					var ppp = param;
-					ppp.format = 1; // 最终保底：全部尝试转化为jpeg
-					byte[] outbuffer = CompressTarget.GetCompressedImageData(in inbuffer, ppp);
-					imageData = ImageDataFactory.Create(outbuffer);
-					imageData.SetDpi(
-						PdfTarget.BaseDpiForDirectLoadComputingSize,
-						PdfTarget.BaseDpiForDirectLoadComputingSize
-					);
+					imageData = CompressTarget.GetCompressedImageData(in buffer, param, optimize);
 				}
 				catch (Exception ex) {
-					log += $"[Iodine] Exception: {ex.Message} by {ex.Source}.";
+					log += $"[Iodine] Exception from {ex.Source}: {ex.Message}";
 					imageData = null;
 				}
+				break;
+			case FileType.Type.BMP:  // Img#, Direct.
+				log += $"[Iodine] Not supports 'BMP' yet.";
+				break;
+			default:
 				break;
 			}
 			return imageData;
 		}
 
-		private ImageData CreateWithCheckingResize(in byte[] inbuffer, ImageParam param) {
-#if DEBUG
-			if (param.reduceByPowOf2 || param.shortSide != 0 || param.longSide != 0) {
-				throw new ArgumentException("Extra parameters not processed.");
+		protected static Stream? LoadImageByImageSharp(FileType.Type type, in Image image, ImageParam param, ref LoadImageLog log) {
+			Stream? imageData = null;
+			switch (type) {
+			case FileType.Type.JPEG: // Iodine, Img#, Direct.
+			case FileType.Type.PNG:  // Iodine, Img#, Direct.
+			case FileType.Type.GIF:  // Iodine, Img#, Direct.
+			case FileType.Type.TIFF: // Iodine, Img#, Direct.
+			case FileType.Type.BMP:  // Img#, Direct.
+			case FileType.Type.WEBP: // Iodine, Img#.
+				try { // ImageSharp目前只会输出PNG和Jpeg，除了指定PNG，其他全部转化为Jpeg.
+					imageData = CompressTarget.GetImageSharpData(in image, param);
+				}
+				catch (Exception ex) {
+					log += $"[ImageSharp] Exception from '{ex.Source}': {ex.Message}";
+					imageData = null;
+				}
+				break;
+			default:
+				break;
 			}
-			if (param.resize && (param.width < 1 || param.height < 1)) {
-				throw new ArgumentException("Parameters is invalid.");
-			}
-#endif
-			var image = ImageDataFactory.Create(inbuffer);
-			image.SetDpi(
-				PdfTarget.BaseDpiForDirectLoadComputingSize,
-				PdfTarget.BaseDpiForDirectLoadComputingSize
-			);
+			return imageData;
+		}
 
+		private static MemoryStream? LoadImageDirectly(FileType.Type type, in byte[] buffer, ImageParam param, ref LoadImageLog log, out int img_w, out int img_h) {
 			if (param.resize) {
-				float xx = image.GetWidth() / param.width;
-				float yy = image.GetHeight() / param.height;
-				image.SetDpi(
-					(int)float.Round(PdfTarget.BaseDpiForDirectLoadComputingSize * xx),
-					(int)float.Round(PdfTarget.BaseDpiForDirectLoadComputingSize * yy)
-				);
+				img_w = param.width;
+				img_h = param.height;
 			}
-
-			return image;
+			else {
+				img_w = -1;
+				img_h = -1;
+			}
+			switch (type) {
+			case FileType.Type.JPEG: // Iodine, Img#, Direct.
+			case FileType.Type.PNG:  // Iodine, Img#, Direct.
+			case FileType.Type.GIF:  // Iodine, Img#, Direct.
+			case FileType.Type.TIFF: // Iodine, Img#, Direct.
+			case FileType.Type.BMP:  // Img#, Direct.
+				break;
+			case FileType.Type.WEBP: // Iodine, Img#.
+			default:
+				log += $"[PDFsharp] Not supports '{type}'.";
+				return null;
+			}
+			MemoryStream? res;
+			try {
+				res = new MemoryStream(buffer, false);
+			}
+			catch (Exception ex) {
+				log += $"[ImageSharp] Exception from {ex.Source}: {ex.Message}";
+				res = null;
+			}
+			return res;
 		}
 
 		static ImageParam ProcessExtra(int org_w, int org_h, ImageParam param) {

--- a/PicMergeToPdf/Merger.cs
+++ b/PicMergeToPdf/Merger.cs
@@ -136,7 +136,7 @@ namespace PicMerge {
 					break;
 				//case 0: // 原格式
 				default:
-					param.format = 2; // To PNG
+					param.format = 1; // To JPEG
 					break;
 				}
 				goto case FileType.Type.JPEG;
@@ -173,7 +173,7 @@ namespace PicMerge {
 				break;
 			//case 0: // 原格式
 			default:
-				param.format = 2; // To PNG
+				param.format = 1; // To JPEG
 				break;
 			} // ImageSharp目前只会输出PNG和Jpeg.
 			goto case FileType.Type.JPEG;*/

--- a/PicMergeToPdf/Merger.cs
+++ b/PicMergeToPdf/Merger.cs
@@ -45,7 +45,7 @@ namespace PicMerge {
 				res.output = ReadImage(in buffer, param, ref res.log, out res.img_w_override, out res.img_h_override);
 			}
 			catch (Exception ex) {
-				res.log += $"[Load] Exception from '{ex.Source}': {ex.Message}";
+				res.log += $"[Load] Exception: {ex.Message}";
 				res.output = null;
 			}
 			if (res.output is null) {
@@ -94,8 +94,8 @@ namespace PicMerge {
 				if (optimize) // 优化则使质量最高，保证不接收optimize的格式也能接近无损
 					param.quality = 100;
 
-				if (param.compress || param.resize) {
-					// 压缩和改变大小都需要尝试处理：
+				if (param.compress || param.format != 0 || param.resize) {
+					// 压缩、改变格式和改变大小都需要尝试处理：
 					// 先尝试Iodine，最大化压缩率；
 					// 再尝试ImageSharp，转换的同时可以压缩；
 					// 最后尝试直接加载。
@@ -118,7 +118,7 @@ namespace PicMerge {
 				}
 			}
 			catch (Exception ex) {
-				log += $"[Read] Exception from '{ex.Source}': {ex.Message}";
+				log += $"[Read] Exception: {ex.Message}";
 				img_stream = null;
 			}
 			return img_stream;
@@ -128,33 +128,34 @@ namespace PicMerge {
 			Stream? imageData = null;
 			switch (type) {
 			case FileType.Type.WEBP: // Iodine, Img#.
-				switch (param.format) {
+			case FileType.Type.GIF:  // Iodine, Img#.
+			case FileType.Type.TIFF: // Iodine, Img#.
+				switch (param.format) { // 必须转换
 				case 1: // JPEG
 				case 2: // PNG
 					break;
-				case 0: // 原格式
+				//case 0: // 原格式
 				default:
-					param.format = 1; // WEBP必须转换
+					param.format = 2; // To PNG
 					break;
 				}
 				goto case FileType.Type.JPEG;
 			case FileType.Type.JPEG: // Iodine, Img#, Direct.
 			case FileType.Type.PNG:  // Iodine, Img#, Direct.
-			case FileType.Type.GIF:  // Iodine, Img#, Direct.
-			case FileType.Type.TIFF: // Iodine, Img#, Direct.
 				try {
 					imageData = CompressTarget.GetCompressedImageData(in buffer, param, optimize);
 				}
 				catch (Exception ex) {
-					log += $"[Iodine] Exception from {ex.Source}: {ex.Message}";
+					log += $"[Iodine] Exception: {ex.Message}";
 					imageData = null;
 				}
 				break;
-			case FileType.Type.BMP:  // Img#, Direct.
-				log += $"[Iodine] Not supports 'BMP' yet.";
-				break;
+			case FileType.Type.BMP:  // Img#.
 			default:
 				break;
+			}
+			if (imageData is null) {
+				log += $"[Iodine] Cannot do it. Type: '{type}'.";
 			}
 			return imageData;
 		}
@@ -162,22 +163,35 @@ namespace PicMerge {
 		protected static Stream? LoadImageByImageSharp(FileType.Type type, in Image image, ImageParam param, ref LoadImageLog log) {
 			Stream? imageData = null;
 			switch (type) {
+			case FileType.Type.GIF:  // Iodine, Img#.
+			case FileType.Type.TIFF: // Iodine, Img#.
+			case FileType.Type.WEBP: // Iodine, Img#.
+			case FileType.Type.BMP:  // Img#.
+			/*switch (param.format) { // 必须转换
+			case 1: // JPEG
+			case 2: // PNG
+				break;
+			//case 0: // 原格式
+			default:
+				param.format = 2; // To PNG
+				break;
+			} // ImageSharp目前只会输出PNG和Jpeg.
+			goto case FileType.Type.JPEG;*/
 			case FileType.Type.JPEG: // Iodine, Img#, Direct.
 			case FileType.Type.PNG:  // Iodine, Img#, Direct.
-			case FileType.Type.GIF:  // Iodine, Img#, Direct.
-			case FileType.Type.TIFF: // Iodine, Img#, Direct.
-			case FileType.Type.BMP:  // Img#, Direct.
-			case FileType.Type.WEBP: // Iodine, Img#.
-				try { // ImageSharp目前只会输出PNG和Jpeg，除了指定PNG，其他全部转化为Jpeg.
+				try {
 					imageData = CompressTarget.GetImageSharpData(in image, param);
 				}
 				catch (Exception ex) {
-					log += $"[ImageSharp] Exception from '{ex.Source}': {ex.Message}";
+					log += $"[ImageSharp] Exception: {ex.Message}";
 					imageData = null;
 				}
 				break;
 			default:
 				break;
+			}
+			if (imageData is null) {
+				log += $"[ImageSharp] Cannot do it. Type: '{type}'.";
 			}
 			return imageData;
 		}
@@ -194,11 +208,11 @@ namespace PicMerge {
 			switch (type) {
 			case FileType.Type.JPEG: // Iodine, Img#, Direct.
 			case FileType.Type.PNG:  // Iodine, Img#, Direct.
-			case FileType.Type.GIF:  // Iodine, Img#, Direct.
-			case FileType.Type.TIFF: // Iodine, Img#, Direct.
-			case FileType.Type.BMP:  // Img#, Direct.
 				break;
+			case FileType.Type.GIF:  // Iodine, Img#.
+			case FileType.Type.TIFF: // Iodine, Img#.
 			case FileType.Type.WEBP: // Iodine, Img#.
+			case FileType.Type.BMP:  // Img#.
 			default:
 				log += $"[PDFsharp] Not supports '{type}'.";
 				return null;
@@ -208,8 +222,11 @@ namespace PicMerge {
 				res = new MemoryStream(buffer, false);
 			}
 			catch (Exception ex) {
-				log += $"[ImageSharp] Exception from {ex.Source}: {ex.Message}";
+				log += $"[PDFsharp] Exception: {ex.Message}";
 				res = null;
+			}
+			if (res is null) {
+				log += $"[PDFsharp] Cannot do it. Type: '{type}'.";
 			}
 			return res;
 		}

--- a/PicMergeToPdf/MergerParallel.cs
+++ b/PicMergeToPdf/MergerParallel.cs
@@ -52,8 +52,13 @@ namespace PicMerge {
 				LoadImageResult load_res = tasks.Dequeue().Result;
 				Stream? imageData = load_res.output;
 				string file = files[landedCnt++];
+#if DEBUG
+				result.Add(new FileResult(0xFFFF0000, file, load_res.log.error_message));
+				if (imageData == null) {
+#else
 				if (imageData == null) {
 					result.Add(new FileResult(0xFFFF0000, file, load_res.log.error_message));
+#endif
 					result.Add(new FileResult(0x80020001, file, StrFailedToRead));
 					FinishOneImg();
 					continue;

--- a/PicMergeToPdf/MergerParallel.cs
+++ b/PicMergeToPdf/MergerParallel.cs
@@ -1,5 +1,4 @@
-﻿using iText.IO.Image;
-using static PicMerge.IMerger;
+﻿using static PicMerge.IMerger;
 
 namespace PicMerge {
 	/// <summary>
@@ -20,11 +19,6 @@ namespace PicMerge {
 		/// </summary>
 		private readonly Action FinishOneImg = finish1img;
 
-		struct LoadResult() {
-			public ImageData? img_data = null;
-			public string log = "";
-		}
-
 		/// <summary>
 		/// 合并文件。此方法文件级并行，即并发加载处理，再依次加入结果。
 		/// </summary>
@@ -34,7 +28,7 @@ namespace PicMerge {
 		/// <returns>无法合入的文件的列表</returns>
 		public virtual List<FileResult> Process(string outputfilepath, List<string> files, string? title = null) {
 			List<FileResult> result = [];
-			Queue<Task<LoadResult>> tasks = [];
+			Queue<Task<LoadImageResult>> tasks = [];
 			var file_cnt = files.Count;
 			var nextfile = files.GetEnumerator();
 
@@ -55,11 +49,11 @@ namespace PicMerge {
 				}
 
 				/// Get image and check
-				LoadResult load_res = tasks.Dequeue().Result;
-				ImageData? imageData = load_res.img_data;
+				LoadImageResult load_res = tasks.Dequeue().Result;
+				Stream? imageData = load_res.output;
 				string file = files[landedCnt++];
 				if (imageData == null) {
-					result.Add(new FileResult(0xFFFF0000, file, load_res.log));
+					result.Add(new FileResult(0xFFFF0000, file, load_res.log.error_message));
 					result.Add(new FileResult(0x80020001, file, StrFailedToRead));
 					FinishOneImg();
 					continue;
@@ -81,13 +75,9 @@ namespace PicMerge {
 		/// <summary>
 		/// 开启一个新的加载图片任务。
 		/// </summary>
-		private Task<LoadResult> ParaLoad(string filepath) {
+		private Task<LoadImageResult> ParaLoad(string filepath) {
 			return Task.Run(() => {
-				LoadResult res = new();
-				LoadImageLog log = new();
-				res.img_data = LoadImage(filepath, m_param, ref log);
-				res.log = log.error_message;
-				return res;
+				return LoadImage(filepath, m_param);
 			});
 		}
 	}

--- a/PicMergeToPdf/MergerSerial.cs
+++ b/PicMergeToPdf/MergerSerial.cs
@@ -1,5 +1,4 @@
-﻿using iText.IO.Image;
-using static PicMerge.IMerger;
+﻿using static PicMerge.IMerger;
 
 namespace PicMerge {
 	/// <summary>
@@ -33,10 +32,10 @@ namespace PicMerge {
 				using PdfTarget pdfTarget = new(outputfilepath, title);
 
 				foreach (var file in files) {
-					LoadImageLog log = new();
-					ImageData? imageData = LoadImage(file, m_param, ref log);
+					LoadImageResult lresult = LoadImage(file, m_param);
+					Stream? imageData = lresult.output;
 					if (imageData == null) {
-						result.Add(new FileResult(0xFFFF0000, file, log.error_message));
+						result.Add(new FileResult(0xFFFF0000, file, lresult.log.error_message));
 						result.Add(new FileResult(0x80010001, file, StrFailedToRead));
 						FinishOneImg();
 						continue;

--- a/PicMergeToPdf/PdfTarget.cs
+++ b/PicMergeToPdf/PdfTarget.cs
@@ -1,132 +1,122 @@
-﻿using iText.IO.Image;
-using iText.Kernel.Geom;
-using iText.Kernel.Pdf;
-using iText.Kernel.Pdf.Canvas;
+﻿using PdfSharp;
+using PdfSharp.Drawing;
+using PdfSharp.Pdf;
+using System.IO;
+using System.Reflection.Metadata;
+using System.Xml.Linq;
 
-namespace PicMerge {
-	internal class PdfTarget(string _outputPath, string? _title) : IDisposable {
+namespace PicMerge;
 
-		internal static int BaseDpiForDirectLoadComputingSize = 4096;
+internal class PdfTarget(string _outputPath, string? _title) : IDisposable {
 
-		private readonly string outputfilepath = _outputPath;
-		private readonly string? title = _title;
+	private readonly string outputfilepath = _outputPath;
+	private readonly string? title = _title;
 
-		/// <summary>
-		/// 文件流。首次使用时创建。
-		/// </summary>
-		private FileStream? _outputFileStream = null;
-		/// <summary>
-		/// 填写器。首次使用时创建。
-		/// </summary>
-		private PdfWriter? _pdfWriter = null;
-		/// <summary>
-		/// 文档。首次使用时创建。
-		/// </summary>
-		private PdfDocument? _pdfDocument = null;
+	/// <summary>
+	/// 文件流。首次使用时创建。
+	/// </summary>
+	private FileStream? _outputFileStream = null;
+	/// <summary>
+	/// 文档。首次使用时创建。
+	/// </summary>
+	private PdfDocument? _pdfDocument = null;
 
-		internal PdfDocument Document {
-			get {
-				if (_pdfDocument == null) {
-					if (_pdfWriter == null) {
-						// 需要写时再打开文件开写。这样的话，如果没有可合入的文件，就不会创建出空文件。
-						if (_outputFileStream == null) {
-							IMerger.EnsureFileCanExsist(outputfilepath);
-							_outputFileStream = new(outputfilepath, FileMode.OpenOrCreate, FileAccess.Write);
-						}
-						WriterProperties writerProperties = new();
-						writerProperties.SetFullCompressionMode(true);
-						writerProperties.SetCompressionLevel(CompressionConstants.DEFAULT_COMPRESSION);
-						_pdfWriter = new(_outputFileStream, writerProperties);
-					}
-					_pdfDocument = new(_pdfWriter);
-					if (title != null)
-						_pdfDocument.GetDocumentInfo().SetTitle(title);
+	internal PdfDocument Document {
+		get {
+			if (_pdfDocument == null) {
+				// 需要写时再打开文件开写。这样的话，如果没有可合入的文件，就不会创建出空文件。
+				if (_outputFileStream == null) {
+					IMerger.EnsureFileCanExsist(outputfilepath);
+					_outputFileStream = new(outputfilepath, FileMode.OpenOrCreate, FileAccess.Write);
 				}
-				return _pdfDocument;
+				_pdfDocument = new(_outputFileStream);
+				_pdfDocument.Options.CompressContentStreams = true;
+				_pdfDocument.Options.FlateEncodeMode = PdfFlateEncodeMode.Default;
+				_pdfDocument.Options.EnableCcittCompressionForBilevelImages = true;
+				_pdfDocument.Options.UseFlateDecoderForJpegImages =
+					PdfUseFlateDecoderForJpegImages.Automatic;
+				if (title != null)
+					_pdfDocument.Info.Title = title;
 			}
+			return _pdfDocument;
 		}
+	}
 
-		~PdfTarget() {
-			Dispose(false);
-		}
+	~PdfTarget() {
+		Dispose(false);
+	}
 
-		internal bool IsUsed() {
-			return _pdfDocument != null;
-		}
+	internal bool IsUsed() {
+		return _pdfDocument != null;
+	}
 
-		/// <summary>
-		/// 向 PDF 添加一页图片。
-		/// </summary>
-		/// <param name="imageData">图片数据</param>
-		/// <param name="param">页面参数</param>
-		/// <param name="index">图片插入在第几页，从1开始</param>
-		/// <returns>是否成功</returns>
-		internal bool AddImage(in ImageData imageData, in PageParam param, int index = -1) {
-			index++;
-			bool fixedWidth = (param.fixedType & PageParam.FixedType.WidthFixed) != 0 && param.width >= 10;
-			bool fixedHeight = (param.fixedType & PageParam.FixedType.HeightFixed) != 0 && param.height >= 10;
-			try {
-				PageSize pageSize;
-				PageSize imageSize;
-				float width = imageData.GetWidth();
-				float height = imageData.GetHeight();
+	/// <summary>
+	/// 向 PDF 添加一页图片。
+	/// </summary>
+	/// <param name="stream_to_image">图片数据流</param>
+	/// <param name="param">页面参数</param>
+	/// <param name="index">图片插入在第几页，从1开始</param>
+	/// <returns>是否成功</returns>
+	internal bool AddImage(in Stream stream_to_image, in PageParam param, int img_w_override = -1, int img_h_override = -1) {
+		bool fixedWidth = (param.fixedType & PageParam.FixedType.WidthFixed) != 0 && param.width >= 10;
+		bool fixedHeight = (param.fixedType & PageParam.FixedType.HeightFixed) != 0 && param.height >= 10;
+		try {
+			using var image = XImage.FromStream(stream_to_image);
 
-				if (fixedWidth && fixedHeight) { // 固定大小
-					pageSize = new(param.width, param.height);
-					float r = float.Min(
-						1.0f * param.width / width,
-						1.0f * param.height / height
-					);
-					imageSize = new(width * r, height * r);
-					imageSize.SetX((pageSize.GetWidth() - imageSize.GetWidth()) / 2.0f);
-					imageSize.SetY((pageSize.GetHeight() - imageSize.GetHeight()) / 2.0f);
-				}
-				else if (fixedWidth) { // 固定宽度
-					imageSize = new(param.width, param.width / width * height);
-					pageSize = imageSize;
-				}
-				else if (fixedHeight) { // 固定高度
-					imageSize = new(param.height / height * width, param.height);
-					pageSize = imageSize;
-				}
-				else { // 与图片大小一致
-					imageSize = new(width, height);
-					pageSize = imageSize;
-				}
+			// 添加新页面并设置尺寸（单位：点）
+			var page = Document.AddPage();
+			var page_w = page.Width;
+			var page_h = page.Height;
 
-				float pageScale = 72.0f / param.dpi;
-				float imageWantedPageScaleX = BaseDpiForDirectLoadComputingSize * 1.0f / imageData.GetDpiX();
-				float imageWantedPageScaleY = BaseDpiForDirectLoadComputingSize * 1.0f / imageData.GetDpiY();
-				pageSize.SetWidth(pageSize.GetWidth() * pageScale * imageWantedPageScaleX);
-				pageSize.SetHeight(pageSize.GetHeight() * pageScale * imageWantedPageScaleY);
+			double img_w = img_w_override > 0 ? img_w_override : image.PixelWidth;
+			double img_h = img_h_override > 0 ? img_h_override : image.PixelHeight;
 
-				imageData.SetDpi(72, 72);
-
-				PdfPage page = (index < 1 || index > Document.GetNumberOfPages()) ? Document.AddNewPage(pageSize) : Document.AddNewPage(index, pageSize);
-				PdfCanvas canvas = new(page);
-				canvas.AddImageFittedIntoRectangle(imageData, imageSize, false);
+			if (fixedWidth && fixedHeight) { // 固定大小
+				page_w.Point = param.width;
+				page_h.Point = param.height;
 			}
-			catch (Exception) {
-				return false;
+			else if (fixedWidth) { // 固定宽度
+				page_w.Point = param.width;
+				page_h.Point = param.width / img_w * img_h;
 			}
-			return true;
-		}
-
-		public void Dispose() {
-			Dispose(true);
-			GC.SuppressFinalize(this);
-		}
-
-		private bool m_disposed = false;
-		protected virtual void Dispose(bool disposing) {
-			if (m_disposed)
-				return;
-			if (disposing) {
-				_pdfDocument?.Close();
-				_pdfWriter?.Dispose();
-				_outputFileStream?.Dispose();
+			else if (fixedHeight) { // 固定高度
+				page_w.Point = param.height / img_h * img_w;
+				page_h.Point = param.height;
 			}
-			m_disposed = true;
+			else { // 与图片大小一致
+				page_w.Point = img_w;
+				page_h.Point = img_h;
+			}
+
+			float page_scale = 72.0f / param.dpi;
+			page_w.Point *= page_scale;
+			page_h.Point *= page_scale;
+
+			// 绘制图片（铺满页面）
+			using var gfx = XGraphics.FromPdfPage(page);
+			gfx.DrawImage(image, 0, 0, page.Width.Point, page.Height.Point);
 		}
+		catch (Exception) {
+			return false;
+		}
+		return true;
+	}
+
+	public void Dispose() {
+		Dispose(true);
+		GC.SuppressFinalize(this);
+	}
+
+	private bool m_disposed = false;
+	protected virtual void Dispose(bool disposing) {
+		if (m_disposed)
+			return;
+		if (disposing) {
+			_pdfDocument?.Close();
+			_pdfDocument?.Dispose();
+			_outputFileStream?.Close();
+			_outputFileStream?.Dispose();
+		}
+		m_disposed = true;
 	}
 }

--- a/PicMergeToPdf/PdfTarget.cs
+++ b/PicMergeToPdf/PdfTarget.cs
@@ -102,6 +102,10 @@ internal class PdfTarget(string _outputPath, string? _title) : IDisposable {
 		catch (Exception) {
 			return false;
 		}
+		finally {
+			stream_to_image.Close();
+			stream_to_image.Dispose();
+		}
 		return true;
 	}
 

--- a/PicMergeToPdf/PdfTarget.cs
+++ b/PicMergeToPdf/PdfTarget.cs
@@ -92,6 +92,9 @@ internal class PdfTarget(string _outputPath, string? _title) : IDisposable {
 			page_w.Point *= page_scale;
 			page_h.Point *= page_scale;
 
+			page.Width = page_w;
+			page.Height = page_h;
+
 			// 绘制图片（铺满页面）
 			using var gfx = XGraphics.FromPdfPage(page);
 			gfx.DrawImage(image, 0, 0, page.Width.Point, page.Height.Point);

--- a/PicMergeToPdf/PicMerge.csproj
+++ b/PicMergeToPdf/PicMerge.csproj
@@ -28,8 +28,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="itext" Version="9.6.0" />
-    <PackageReference Include="itext.bouncy-castle-adapter" Version="9.6.0" />
+    <PackageReference Include="PDFsharp" Version="6.2.4" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
   </ItemGroup>
 

--- a/PicMergeToPdf/Processor.cs
+++ b/PicMergeToPdf/Processor.cs
@@ -364,9 +364,9 @@ namespace PicMerge {
 			if (failed.Any()) {
 				foreach (var str in failed) {
 					if (str.code == 0xFFFF0000 && !string.IsNullOrEmpty(str.description))
-						Logger.Log(str.description);
+						Logger.Log('\n' + str.description);
 					else
-						Logger.Log($"[Failed] At \"{title}\" from \"{str.filename}\", because \"{str.description}\" (Code: {str.code:X}).\n");
+						Logger.Log($"[Failed] At \"{title}\" from \"{str.filename}\", because \"{str.description}\" (Code: {str.code:X}).");
 				}
 				m_haveFailedFiles = true;
 			}

--- a/WpfGui/DictionaryMainGUI.xaml
+++ b/WpfGui/DictionaryMainGUI.xaml
@@ -25,7 +25,8 @@
     <sys:String x:Key="CannotProcess" xml:space="preserve"
 >Some files cannot be processed.
 Check log file for details:
-{0}</sys:String>
+{0}
+Answer 'Yes' to view the log.</sys:String>
     <sys:String x:Key="ChooseDestinationDir">Choose output place</sys:String>
     <sys:String x:Key="ChooseMoveDestinationDir">Choose move destination</sys:String>
 

--- a/WpfGui/DictionaryMainGUI.zh-CN.xaml
+++ b/WpfGui/DictionaryMainGUI.zh-CN.xaml
@@ -25,7 +25,8 @@
     <sys:String x:Key="CannotProcess" xml:space="preserve"
 >一些文件无法处理。
 查看日志以了解详情：
-{0}</sys:String>
+{0}
+若要查看该日志，请选择“是”。</sys:String>
     <sys:String x:Key="ChooseDestinationDir">选择输出位置</sys:String>
     <sys:String x:Key="ChooseMoveDestinationDir">选择移动位置</sys:String>
 

--- a/WpfGui/MainWindow.xaml.cs
+++ b/WpfGui/MainWindow.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System.Globalization;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
@@ -88,17 +89,55 @@ namespace WpfGui {
 			}
 		}
 
+
+		[LibraryImport("shell32.dll")]
+		private static partial void ILFree(IntPtr pidlList);
+
+		[LibraryImport("shell32.dll", StringMarshalling = StringMarshalling.Utf16)]
+		private static partial IntPtr ILCreateFromPathW(string pszPath);
+
+		[LibraryImport("shell32.dll")]
+		private static partial int SHOpenFolderAndSelectItems(IntPtr pidlList, uint cild, IntPtr children, uint dwFlags);
+
+		private void OpenFolderAndSelectFile(string filePath) {
+			// 确保文件路径是绝对路径
+			filePath = Path.GetFullPath(filePath);
+
+			// 获取文件的 PIDL (Pointer to an Item ID List)
+			IntPtr pidlList = ILCreateFromPathW(filePath);
+
+			if (pidlList != IntPtr.Zero) {
+				try {
+					// 调用 API 打开资源管理器并选中文件
+					// 第三个参数为 IntPtr.Zero 表示只选中一个文件
+					SHOpenFolderAndSelectItems(pidlList, 0, IntPtr.Zero, 0);
+				}
+				finally {
+					// 释放 PIDL 资源
+					ILFree(pidlList);
+				}
+			}
+		}
+
 		private void PopWarning(string logPath) {
 			App.Current.Dispatcher.Invoke(() => {
 				TaskbarItemInfo.ProgressState = System.Windows.Shell.TaskbarItemProgressState.Error;
 				Activate();
-				MessageBox.Show(
+				var choice = MessageBox.Show(
 					this,
-					string.Format(App.Current.TryFindResource("CannotProcess") as string ?? "Failed files in log: {0}", logPath),
+					string.Format(
+						App.Current.TryFindResource("CannotProcess") as string
+						?? "Failed files in log: {0}" + Environment.NewLine + "Open it?",
+						logPath
+						),
 					$"{Title}: {App.Current.TryFindResource("Warning")}",
-					MessageBoxButton.OK,
-					MessageBoxImage.Warning
+					MessageBoxButton.YesNo,
+					MessageBoxImage.Warning,
+					MessageBoxResult.Yes
 				);
+				if (choice == MessageBoxResult.Yes) {
+					OpenFolderAndSelectFile(logPath);
+				}
 			});
 		}
 

--- a/WpfGui/WpfGui.csproj
+++ b/WpfGui/WpfGui.csproj
@@ -18,6 +18,8 @@
     <Description>Pictures2PDF - GUI</Description>
     <PackageId>$(AssemblyName)</PackageId>
     <Title>$(AssemblyName)</Title>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/WpfGui/app.manifest
+++ b/WpfGui/app.manifest
@@ -1,0 +1,79 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="MyApplication.app"/>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <!-- UAC 清单选项
+             如果想要更改 Windows 用户帐户控制级别，请使用
+             以下节点之一替换 requestedExecutionLevel 节点。
+
+        <requestedExecutionLevel  level="asInvoker" uiAccess="false" />
+        <requestedExecutionLevel  level="requireAdministrator" uiAccess="false" />
+        <requestedExecutionLevel  level="highestAvailable" uiAccess="false" />
+
+            指定 requestedExecutionLevel 元素将禁用文件和注册表虚拟化。
+            如果你的应用程序需要此虚拟化来实现向后兼容性，则移除此
+            元素。
+        -->
+        <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- 设计此应用程序与其一起工作且已针对此应用程序进行测试的
+           Windows 版本的列表。取消评论适当的元素，
+           Windows 将自动选择最兼容的环境。 -->
+
+      <!-- Windows Vista -->
+      <!--<supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}" />-->
+
+      <!-- Windows 7 -->
+      <!--<supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}" />-->
+
+      <!-- Windows 8 -->
+      <!--<supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}" />-->
+
+      <!-- Windows 8.1 -->
+      <!--<supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}" />-->
+
+      <!-- Windows 10 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+
+    </application>
+  </compatibility>
+
+  <!-- 指示该应用程序可感知 DPI 且 Windows 在 DPI 较高时将不会对其进行
+       自动缩放。Windows Presentation Foundation (WPF)应用程序自动感知 DPI，无需
+       选择加入。选择加入此设置的 Windows 窗体应用程序(面向 .NET Framework 4.6)还应
+       在其 app.config 中将 "EnableWindowsFormsHighDpiAutoResizing" 设置设置为 "true"。
+       
+       将应用程序设为感知长路径。请参阅 https://docs.microsoft.com/windows/win32/fileio/maximum-file-path-limitation -->
+  
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <!--<dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>-->
+      <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
+    </windowsSettings>
+  </application>
+  
+
+  <!-- 启用 Windows 公共控件和对话框的主题(Windows XP 和更高版本) -->
+  
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity
+          type="win32"
+          name="Microsoft.Windows.Common-Controls"
+          version="6.0.0.0"
+          processorArchitecture="*"
+          publicKeyToken="6595b64144ccf1df"
+          language="*"
+        />
+    </dependentAssembly>
+  </dependency>
+  
+
+</assembly>


### PR DESCRIPTION
Using PDFsharp allows program to use stream instead of byte[], and reduces memory copy.